### PR TITLE
Add option to replace 3PIDs in synapse if removed/changed in the backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,14 +87,16 @@ If you would like to change the behaviour, you can use the following configurati
 ```
 
 3PIDs received from the backend are merged with the ones already linked to the account.
-If you would like to change this behaviour, you can use the following configuration item:
+If you would like to change this behaviour, you can use the following configuration items:
 ```yaml
     config:
       policy:
         all:
           threepid:
             update: false
+            replace: false
 ```
+If update is set to `false`, the 3PIDs will not be changed at all. If replace is set to `true`, all 3PIDs not available in the backend anymore will be deleted from synapse.
 
 ## Integrate
 To use this module with your back-end, you will need to implement a single REST endpoint:


### PR DESCRIPTION
This patch allows 3PIDs to be deleted from synapse if they are not available anymore in the backend.